### PR TITLE
Set FoliageShadowImposterComponent Mobility to Static instead of Movable.

### DIFF
--- a/src/Plugins/FoliageShadowImposters/Source/FoliageShadowImposters/Private/FoliageShadowImposters.cpp
+++ b/src/Plugins/FoliageShadowImposters/Source/FoliageShadowImposters/Private/FoliageShadowImposters.cpp
@@ -106,6 +106,7 @@ void FFoliageShadowImpostersModule::AddFoliageShadowImpostersForThisMesh(FString
 							NewImposterMeshComponent->AttachToComponent(CurrentFoliageActor->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
 							UStaticMesh* ImposterMeshToUse = Cast<UStaticMesh>(StaticLoadObject(UStaticMesh::StaticClass(), NULL, *FoliageShadowImposterMeshPath));
 							NewImposterMeshComponent->SetStaticMesh(ImposterMeshToUse);
+							NewImposterMeshComponent->SetMobility(EComponentMobility::Static);
 							CurrentFoliageActor->Modify();
 
 							FTransform InstanceTransform;


### PR DESCRIPTION
Set FoliageShadowImposterComponent Mobility to Static instead of Movable.

This fixes the following warning during map checks:
InstancedFoliageActor_0 Large actor receives a pre-shadow and will cause an extreme performance hit unless bCastDynamicShadow is set to false